### PR TITLE
Add Korean translation

### DIFF
--- a/lib/translations.py
+++ b/lib/translations.py
@@ -22,4 +22,5 @@ LITS = {
     'sk': [ "Nov",          "Prvá štvrť",       "Úplnok",       "Posledná štvrť"    ],
     'sr': [ "Mlađak",       "Prva četvrt",      "Uštap",        "Poslednja četvrt"  ],
     'uk': [ "Молодик",      "Перша чверть",     "Повня",        "Остання чверть"    ],
+    'ko': [ "초승달",      "상현달",     "보름달",        "하현달"    ],
 }


### PR DESCRIPTION
In Korean, `상현` means `First Quarter`, and `상현달` means `First Quarter Moon`, also `하현` too.
So I put the word `달` after `상현` but if it goes against the convention, I will commit again except `달` in the letters.