### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/lib/astro.py
+++ b/lib/astro.py
@@ -28,6 +28,9 @@
 # Ported to Python by Igor Chubin, 2016
 #
 
+from __future__ import print_function
+
+import sys
 from math import floor, sin, cos, sqrt, tan, atan, atan2, asin
 
 #  Astronomical constants 
@@ -81,7 +84,7 @@ def dcos(x):
 
 
 def fatal(s):
-    print >>sys.stderr, s
+    print(s, file=sys.stderr)
     sys.exit(1)
 
 #


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.